### PR TITLE
Initialize backend server and add Artist model schema

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,39 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const cors = require('cors');
+const path = require('path');
+require('dotenv').config();
+
+const app = express();
+const PORT = process.env.PORT || 5000;
+
+// Middleware
+app.use(cors());
+app.use(express.json());
+app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
+
+// MongoDB connection
+mongoose.connect(process.env.MONGODB_URI || 'mongodb://localhost:27017/gambian-art', {
+  useNewUrlParser: true,
+  useUnifiedTopology: true,
+});
+
+mongoose.connection.on('connected', () => {
+  console.log('Connected to MongoDB');
+});
+
+mongoose.connection.on('error', (err) => {
+  console.error('MongoDB connection error:', err);
+});
+
+// Routes
+app.use('/api/artists', require('./routes/artists'));
+app.use('/api/artworks', require('./routes/artworks'));
+
+app.get('/', (req, res) => {
+  res.json({ message: 'Gambian Art Platform API' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
Set up an Express server with MongoDB connection and define the Artist model schema, including validation and timestamps.